### PR TITLE
fixed: "removeItem" doesn't work in Android device.

### DIFF
--- a/src/android/nl/afas/cordova/plugin/secureLocalStorage/SecureLocalStorage.java
+++ b/src/android/nl/afas/cordova/plugin/secureLocalStorage/SecureLocalStorage.java
@@ -290,7 +290,7 @@ public class SecureLocalStorage extends CordovaPlugin {
         if (action.equals("setItem")){
             return ActionId.ACTION_SETITEM;
         }
-        if (action.equals("clear")){
+        if (action.equals("removeItem")){
             return ActionId.ACTION_REMOVEITEM;
         }
         if (action.equals("clearIfInvalid")){


### PR DESCRIPTION
I found a bug that "removeItem()" doesn't work in Android device and fix it.
